### PR TITLE
Improve PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Nick Logozzo <nlogozzo225@gmail.com>
-_name=nickvision-tagger
-pkgname=$_name
+
+pkgname=nickvision-tagger
 pkgver=2022.5.5
 pkgrel=1
 pkgdesc="An easy-to-use music tag (metadata) editor"
@@ -9,17 +9,16 @@ url="https://github.com/nlogozzo/NickvisionTagger"
 license=(GPL3)
 depends=(gtk4 libadwaita jsoncpp libcurlpp taglib libmusicbrainz5)
 makedepends=(git cmake)
-provides=($_name)
-conflicts=($_name)
-source=("git+https://github.com/nlogozzo/NickvisionTagger.git")
-md5sums=("SKIP")
+source=("git+https://github.com/nlogozzo/NickvisionTagger.git#tag=${pkgver}"
+        "git+https://github.com/Makman2/GCR_CMake.git")
+sha256sums=('SKIP'
+            'SKIP')
 
 prepare() {
     mkdir -p build
-    mkdir -p ~/.local/share/icons/hicolor
     cd $srcdir/NickvisionTagger
-    git checkout -q d056dd9
     git submodule init
+    git config submodule.GCR_CMake.url "${srcdir}/GCR_CMake"
     git submodule update
 }
 
@@ -27,13 +26,12 @@ build() {
 	cd build
     cmake $srcdir/NickvisionTagger \
     -DCMAKE_INSTALL_PREFIX=/usr \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=Release
     make
 }
 
 package() {
 	cd build
 	make DESTDIR="$pkgdir/" install
-    sudo touch /usr/share/icons/hicolor ~/.local/share/icons/hicolor
-    sudo gtk-update-icon-cache
+    ln -s /usr/bin/org.nickvision.tagger ${pkgdir}/usr/bin/nickvision
 }


### PR DESCRIPTION
Hello, I've the program from AUR new feed and took a look at the pkgbuild, some things need or could to be improved

* variable _name which is equal to pkgname is not needed
* provides and conflicts are not needed (are 'variations' that need to provide and conflicts nickvision-tagger)
* sha256sums is preferred
* git submodules need to be downloaded in source=() and configured
* is prohibited to touch users home, gtk-update-icon-cache is done by a pacman hook at installation