### PR TITLE
Fix %track%- %title% tagToFilename Not Working

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@
 - Convert filenames to tags and tags to filenames with ease
 - Easily download tag data from the internet with the click of a button (powered by libmusicbrainz5)
 
+# Installation
+
+<table>
+  <tr>
+    <td>Flatpak</td>
+    <td>AUR</td>
+  </tr>
+  <tr>
+    <td>
+      <a href='https://flathub.org/apps/details/org.nickvision.tagger'><img width='130' alt='Download on Flathub' src='https://flathub.org/assets/badges/flathub-badge-en.png'/></a>
+    </td>
+    <td>
+      <a href='https://aur.archlinux.org/packages/nickvision-tagger'>Stable</a>
+    </td>
+  </tr>
+</table>
+
 # Screenshots
 ![MainWindow](https://user-images.githubusercontent.com/17648453/173400558-ec011b3b-fdeb-4718-99ff-f5028c02e423.png)
 ![MusicFolder](https://user-images.githubusercontent.com/17648453/171565079-5287d6c1-2698-48be-b9fd-eea1be912697.png)

--- a/models/musicfile.cpp
+++ b/models/musicfile.cpp
@@ -787,7 +787,7 @@ bool MusicFile::tagToFilename(const std::string& formatString)
         }
         setFilename(getTitle() + "- " + getArtist() + m_path.extension().string());
     }
-    else if (formatString == "%track%- %title")
+    else if (formatString == "%track%- %title%")
     {
         if(getTitle().empty())
         {


### PR DESCRIPTION
Format string was trying to match %track%- %title, however, the string
that should be matched is %track%- %title% (missing last %). This makes
%track%- %title% work properly.