### PR TITLE
mediahelpers.cpp: use an explicit cast

### DIFF
--- a/src/helpers/mediahelpers.cpp
+++ b/src/helpers/mediahelpers.cpp
@@ -35,7 +35,7 @@ std::string MediaHelpers::durationToString(int durationInSeconds)
 std::string MediaHelpers::fileSizeToString(std::uintmax_t fileSize)
 {
     std::vector<std::string> sizes{ _("B"), _("KB"), _("MB"), _("GB"), _("TB") };
-    double size{ fileSize };
+    double size{ static_cast<double>(fileSize) };
     int index{ 0 };
     std::stringstream builder;
     while (size >= 1024 && index < 4)


### PR DESCRIPTION
Bug: https://bugs.gentoo.org/898372